### PR TITLE
Proper async API usage in Singlr Hub

### DIFF
--- a/real-time-assets-tracking-with-signalr/AzureSamples.RealTimeAssetsTrackingWithSignalR.API/Hubs/LiveTrackingHub.cs
+++ b/real-time-assets-tracking-with-signalr/AzureSamples.RealTimeAssetsTrackingWithSignalR.API/Hubs/LiveTrackingHub.cs
@@ -1,4 +1,5 @@
-﻿using AzureSamples.RealTimeAssetsTrackingWithSignalR.API.Model;
+﻿using System.Threading.Tasks;
+using AzureSamples.RealTimeAssetsTrackingWithSignalR.API.Model;
 using Microsoft.AspNetCore.SignalR;
 
 namespace AzureSamples.RealTimeAssetsTrackingWithSignalR.API.Hubs
@@ -10,9 +11,9 @@ namespace AzureSamples.RealTimeAssetsTrackingWithSignalR.API.Hubs
         /// </summary>
         /// <param name="locationUpdate"></param>
         [HubMethodName("location-update")]
-        public void LocationUpdate(LocationUpdate locationUpdate)
+        public Task LocationUpdate(LocationUpdate locationUpdate)
         {
-            Clients.All.SendAsync("location-update", locationUpdate);
+            return Clients.All.SendAsync("location-update", locationUpdate);
         }
     }
 }


### PR DESCRIPTION
This PR fixes an issue with the call to `SendAsync` not being awaited properly. According to the [Signalr documentation](https://docs.microsoft.com/en-us/aspnet/core/signalr/hubs?view=aspnetcore-3.1#create-and-use-hubs)

> Use await when calling asynchronous methods that depend on the hub staying alive. For example, a method such as `Clients.All.SendAsync(...)` can fail if it's called without await and the hub method completes before `SendAsync` finishes.